### PR TITLE
Add procedure to enable bucket versioning of terraform state saving bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Create S3 bucket for Terraform state saving:
 
 ```bash
 $ aws s3 mb s3://foobar-sample-spa-terraform-state --region ap-northeast-1
+$ aws s3api put-bucket-versioning --bucket foobar-sample-spa-terraform-state \
+                                  --versioning-configuration Status=Enabled
 ```
 
 Create CodeBuild's service role for setup:


### PR DESCRIPTION
It is highly recommended that enable bucket versioning of terraform state saving bucket.
Therefore, I think that the procedure is necessary in Getting Started.

ref: https://www.terraform.io/docs/backends/types/s3.html
> Warning! It is highly recommended that you enable Bucket Versioning on the S3 bucket to allow for state recovery in the case of accidental deletions and human error.

