### PR TITLE
Change from aws_iam_policy_attachment to aws_iam_role_policy_attachment

### DIFF
--- a/modules/iam/build_service/main.tf
+++ b/modules/iam/build_service/main.tf
@@ -12,9 +12,8 @@ resource "aws_iam_role" "build_service" {
   assume_role_policy = "${data.template_file.iam_assume_role_policy_build_service.rendered}"
 }
 
-resource "aws_iam_policy_attachment" "build_service" {
-  name       = "${var.resource_prefix}-codebuild-service-deploy-role-attachment-01"
-  roles      = ["${aws_iam_role.build_service.name}"]
+resource "aws_iam_role_policy_attachment" "build_service" {
+  role       = "${aws_iam_role.build_service.name}"
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 

--- a/modules/iam/e2e/main.tf
+++ b/modules/iam/e2e/main.tf
@@ -12,9 +12,8 @@ resource "aws_iam_role" "e2e" {
   assume_role_policy = "${data.template_file.iam_assume_role_policy_e2e.rendered}"
 }
 
-resource "aws_iam_policy_attachment" "e2e" {
-  name       = "${var.resource_prefix}-codebuild-e2e-role-attachment-01"
-  roles      = ["${aws_iam_role.e2e.name}"]
+resource "aws_iam_role_policy_attachment" "e2e" {
+  role       = "${aws_iam_role.e2e.name}"
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 

--- a/modules/iam/test_api/main.tf
+++ b/modules/iam/test_api/main.tf
@@ -12,9 +12,8 @@ resource "aws_iam_role" "test_api" {
   assume_role_policy = "${data.template_file.iam_assume_role_policy_test_api.rendered}"
 }
 
-resource "aws_iam_policy_attachment" "test_api" {
-  name       = "${var.resource_prefix}-codebuild-test-api-role-attachment-01"
-  roles      = ["${aws_iam_role.test_api.name}"]
+resource "aws_iam_role_policy_attachment" "test_api" {
+  role       = "${aws_iam_role.test_api.name}"
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 

--- a/modules/iam/test_web/main.tf
+++ b/modules/iam/test_web/main.tf
@@ -12,9 +12,8 @@ resource "aws_iam_role" "test_web" {
   assume_role_policy = "${data.template_file.iam_assume_role_policy_test_web.rendered}"
 }
 
-resource "aws_iam_policy_attachment" "test_web" {
-  name       = "${var.resource_prefix}-codebuild-test-web-role-attachment-01"
-  roles      = ["${aws_iam_role.test_web.name}"]
+resource "aws_iam_role_policy_attachment" "test_web" {
+  role       = "${aws_iam_role.test_web.name}"
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 


### PR DESCRIPTION
https://www.terraform.io/docs/providers/aws/r/iam_policy_attachment.html

> WARNING: The aws_iam_policy_attachment resource creates exclusive attachments of IAM policies. Across the entire AWS account, all of the users/roles/groups to which a single policy is attached must be declared by a single aws_iam_policy_attachment resource. This means that even any users/roles/groups that have the attached policy via any other mechanism (including other Terraform resources) will have that attached policy revoked by this resource. Consider aws_iam_role_policy_attachment, aws_iam_user_policy_attachment, or aws_iam_group_policy_attachment instead. These resources do not enforce exclusive attachment of an IAM policy.
